### PR TITLE
Fix single-ticker handling in price fetcher

### DIFF
--- a/fetchers/price_fetcher.py
+++ b/fetchers/price_fetcher.py
@@ -1,10 +1,36 @@
 
 import yfinance as yf
+import pandas as pd
+
 
 def get_latest_price(ticker_list):
+    """Fetch the latest closing price for each ticker.
+
+    yfinance behaves differently when a single ticker is requested – it
+    returns a Series instead of a DataFrame.  The previous implementation
+    assumed the result was always a DataFrame with ticker symbols as
+    columns, causing single-ticker requests to return an empty result.
+
+    This function now normalises the response so that both single and
+    multiple ticker queries work consistently.
+    """
+
+    if not ticker_list:
+        return {}
+
     data = yf.download(ticker_list, period="1d", interval="1d")
     prices = {}
-    for ticker in ticker_list:
-        if ticker in data["Close"]:
-            prices[ticker] = data["Close"][ticker].iloc[-1]
+
+    # `data["Close"]` is a Series when a single ticker is requested and a
+    # DataFrame (with ticker symbols as columns) when multiple tickers are
+    # requested.  Handle both cases explicitly.
+    close = data["Close"] if "Close" in data else data
+
+    if isinstance(close, pd.Series):
+        prices[ticker_list[0]] = close.iloc[-1]
+    else:
+        for ticker in ticker_list:
+            if ticker in close.columns:
+                prices[ticker] = close[ticker].iloc[-1]
+
     return prices

--- a/tests/test_price_fetcher.py
+++ b/tests/test_price_fetcher.py
@@ -1,0 +1,19 @@
+import os
+import sys
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from fetchers import price_fetcher
+
+
+def test_get_latest_price_single_ticker(monkeypatch):
+    """Ensure a single-ticker query returns a price."""
+    def fake_download(tickers, period="1d", interval="1d"):
+        # Mimic yfinance's return for a single ticker: a DataFrame with a
+        # "Close" column containing a Series.
+        return pd.DataFrame({"Close": [123.45]})
+
+    monkeypatch.setattr(price_fetcher.yf, "download", fake_download)
+
+    result = price_fetcher.get_latest_price(["AAPL"])
+    assert result == {"AAPL": 123.45}


### PR DESCRIPTION
## Summary
- handle single ticker results from yfinance to ensure closing price is returned
- add regression test for single ticker price fetcher

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68945f2ec608833085fa79600c6ca0dd